### PR TITLE
Add support for slash commands

### DIFF
--- a/src/AdvancedBot.Core/AdvancedBot.Core.csproj
+++ b/src/AdvancedBot.Core/AdvancedBot.Core.csproj
@@ -8,6 +8,6 @@
     <PackageReference Include="LiteDB" Version="5.0.9"/>
     <PackageReference Include="Humanizer" Version="2.8.26"/>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0-preview.3.21201.4"/>
-    <PackageReference Include="Discord.Net.Labs" Version="3.0.3"/>
+    <PackageReference Include="Discord.Net.Labs" Version="3.6.1"/>
   </ItemGroup>
 </Project>

--- a/src/AdvancedBot.Core/BotClient.cs
+++ b/src/AdvancedBot.Core/BotClient.cs
@@ -56,7 +56,11 @@ namespace AdvancedBot.Core
             => Console.WriteLine($"{msg.Source}: {msg.Message}");
 
         private async Task OnReadyAsync()
-            => await _client.SetGameAsync("Being a bot.");
+        {
+            // has to be on ready to avoid auth exception
+            await _services.GetRequiredService<CommandHandlerService>().InitializeSlashCommands();
+            await _client.SetGameAsync("Being a bot.");
+        }
 
         private ServiceProvider ConfigureServices()
         {

--- a/src/AdvancedBot.Core/Commands/Attributes/RequireCustomPermission.cs
+++ b/src/AdvancedBot.Core/Commands/Attributes/RequireCustomPermission.cs
@@ -4,7 +4,7 @@ using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 
-namespace AdvancedBot.Core.Commands.Preconditions
+namespace AdvancedBot.Core.Commands.Attributes
 {
     public class RequireCustomPermission : PreconditionAttribute
     {

--- a/src/AdvancedBot.Core/Commands/Attributes/SlashCommandAttribute.cs
+++ b/src/AdvancedBot.Core/Commands/Attributes/SlashCommandAttribute.cs
@@ -1,0 +1,8 @@
+using Discord.Commands;
+
+namespace AdvancedBot.Core.Commands.Attributes
+{
+    public class SlashCommandAttribute : CommandAttribute
+    {
+    }
+}

--- a/src/AdvancedBot.Core/Commands/Attributes/SlashCommandAttribute.cs
+++ b/src/AdvancedBot.Core/Commands/Attributes/SlashCommandAttribute.cs
@@ -1,8 +1,6 @@
-using Discord.Commands;
+using System;
 
 namespace AdvancedBot.Core.Commands.Attributes
 {
-    public class SlashCommandAttribute : CommandAttribute
-    {
-    }
+    public class SlashCommandAttribute : Attribute { }
 }

--- a/src/AdvancedBot.Core/Commands/CustomCommandService.cs
+++ b/src/AdvancedBot.Core/Commands/CustomCommandService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AdvancedBot.Core.Commands.Attributes;
 using AdvancedBot.Core.Services;
 using Discord;
 using Discord.Commands;
@@ -189,6 +190,84 @@ namespace AdvancedBot.Core.Commands
             }
             
             return $"{prefix}{command.Aliases[0]} {parameters}";
+        }
+
+        public SlashCommandProperties[] GetDesiredSlashCommands()
+        {
+            var attributedCommands = GetSlashAttributeCommands();
+            var slashCommands = new List<SlashCommandProperties>();
+
+            for (int i = 0; i < attributedCommands.Length; i++)
+            {
+                var scb = new SlashCommandBuilder();
+
+                scb.WithName(attributedCommands[i].Name);
+                scb.WithDescription(attributedCommands[i].Summary);
+
+                for (int j = 0; j < attributedCommands[i].Parameters.Count; j++)
+                {
+                    var param = attributedCommands[i].Parameters[j];
+                    scb.AddOption(param.Name, ParameterToCommandOptionType(param), param.Summary, param.IsOptional);
+                }
+
+                slashCommands.Add(scb.Build());
+            }
+
+            return slashCommands.ToArray();
+        }
+
+        private CommandInfo[] GetSlashAttributeCommands()
+        {
+            var slashCommands = new List<CommandInfo>();
+
+            for (int i = 0; i < Modules.Count(); i++)
+            {
+                var module = Modules.ElementAt(i);
+
+                for (int j = 0; j < module.Commands.Count; j++)
+                {
+                    var command = module.Commands[j];
+
+                    if (command.Attributes.FirstOrDefault(x => (SlashCommandAttribute)x != null) != null)
+                    {
+                        slashCommands.Add(command);
+                    }
+                }
+            }
+
+            return slashCommands.ToArray();
+        }
+
+        private ApplicationCommandOptionType ParameterToCommandOptionType(ParameterInfo param)
+        {
+            if (param.Type == typeof(double))
+            {
+                return ApplicationCommandOptionType.Number;
+            }
+            else if (param.Type == typeof(int))
+            {
+                return ApplicationCommandOptionType.Integer;
+            }
+            else if (param.Type == typeof(bool))
+            {
+                return ApplicationCommandOptionType.Boolean;
+            }
+            else if (param.Type == typeof(IChannel))
+            {
+                return ApplicationCommandOptionType.Channel;
+            }
+            else if (param.Type == typeof(IUser))
+            {
+                return ApplicationCommandOptionType.User;
+            }
+            else if (param.Type == typeof(IRole))
+            {
+                return ApplicationCommandOptionType.Role;
+            }
+            else
+            {
+                return ApplicationCommandOptionType.String;
+            }
         }
     }
 }

--- a/src/AdvancedBot.Core/Commands/Modules/Base/CommandInformationModule.cs
+++ b/src/AdvancedBot.Core/Commands/Modules/Base/CommandInformationModule.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;

--- a/src/AdvancedBot.Core/Commands/Modules/Base/CommandPermissionsModule.cs
+++ b/src/AdvancedBot.Core/Commands/Modules/Base/CommandPermissionsModule.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
-using AdvancedBot.Core.Commands.Preconditions;
+using AdvancedBot.Core.Commands.Attributes;
 using AdvancedBot.Core.Services.Commands;
 using Discord;
 using Discord.Commands;

--- a/src/AdvancedBot.Core/Commands/Modules/Base/PrefixModule.cs
+++ b/src/AdvancedBot.Core/Commands/Modules/Base/PrefixModule.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
-using AdvancedBot.Core.Commands.Preconditions;
+using AdvancedBot.Core.Commands.Attributes;
 
 namespace AdvancedBot.Core.Commands.Modules.Base
 {

--- a/src/AdvancedBot.Core/Commands/Modules/Base/PurgeModule.cs
+++ b/src/AdvancedBot.Core/Commands/Modules/Base/PurgeModule.cs
@@ -15,14 +15,20 @@ namespace AdvancedBot.Core.Commands.Modules.Base
     public class PurgeModule : TopModule
     {
         [Command("")]
+        [SlashCommand]
         [Summary("Purges the last x messages.")]
-        public async Task DefaultPurgeAsync(int search = 100)
+        public async Task DefaultPurgeAsync([Summary("The amount of messages to check")] int search = 100)
             => await ReplyAsync($"", false, await HandlePurgeCommandAsync(search));
 
         [Command("user")]
+        [SlashCommand]
         [Summary("Purges the last x messages by said user.")]
-        public async Task PurgeUserAsync(IUser user, int search = 100)
-            => await ReplyAsync($"", false, await HandlePurgeCommandAsync(search, user));
+        public async Task PurgeUserAsync(
+            [Summary("The user you want to purge")] IUser user,
+            [Summary("The amount of messages to check")] int search = 100)
+        {
+            await ReplyAsync($"", false, await HandlePurgeCommandAsync(search, user));
+        }
 
         private async Task<Embed> HandlePurgeCommandAsync(int amount, IUser user = null)
         {

--- a/src/AdvancedBot.Core/Commands/Modules/Base/PurgeModule.cs
+++ b/src/AdvancedBot.Core/Commands/Modules/Base/PurgeModule.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using AdvancedBot.Core.Commands.Preconditions;
+using AdvancedBot.Core.Commands.Attributes;
 using Discord;
 using Discord.Commands;
 

--- a/src/AdvancedBot.Core/Commands/TopModule.cs
+++ b/src/AdvancedBot.Core/Commands/TopModule.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace AdvancedBot.Core.Commands
 {
-    public class TopModule : ModuleBase<SocketCommandContext>
+    public class TopModule : ModuleBase<CommandContext>
     {
         public GuildAccountService Accounts { get; set; }
         public CustomCommandService Commands { get; set; }

--- a/src/AdvancedBot.Core/Services/Commands/CommandHandlerService.cs
+++ b/src/AdvancedBot.Core/Services/Commands/CommandHandlerService.cs
@@ -64,7 +64,10 @@ namespace AdvancedBot.Core.Services.Commands
         private async Task OnSlashCommandExecuted(SocketSlashCommand cmd)
         {
             await cmd.DeferAsync();
-            var a = cmd.Data.Name;
+            var msg = await cmd.GetOriginalResponseAsync();
+
+            var context = new CommandContext(_client, msg);
+            await _commands.ExecuteAsync(context, 0, _services);
         }
 
         private async Task OnMessageReceived(SocketMessage msg)

--- a/src/AdvancedBot.Core/Services/Commands/CommandHandlerService.cs
+++ b/src/AdvancedBot.Core/Services/Commands/CommandHandlerService.cs
@@ -34,6 +34,7 @@ namespace AdvancedBot.Core.Services.Commands
 
             await InitializeSlashCommands();
 
+            _client.SlashCommandExecuted += OnSlashCommandExecuted;
             _client.MessageReceived += OnMessageReceived;
             _commands.CommandExecuted += OnCommandExecuted;
         }
@@ -41,19 +42,29 @@ namespace AdvancedBot.Core.Services.Commands
         private async Task InitializeSlashCommands()
         {
             var desiredCommands = _commands.GetDesiredSlashCommands();
-            var existingCommands = (await _client.GetGlobalApplicationCommandsAsync()).ToArray();
+            //var existingCommands = (await _client.GetGlobalApplicationCommandsAsync()).ToArray();
 
-            for (int i = 0; i < desiredCommands.Length; i++)
-            {
-                // only create if nothing similar was found
-                if (existingCommands.FirstOrDefault(
-                    x => x.Name == desiredCommands[i].Name.GetValueOrDefault()
-                    && x.Description == desiredCommands[i].Description.GetValueOrDefault()
-                    && x.Options.Count == desiredCommands[i].Options.GetValueOrDefault().Count) == null)
-                {
-                    await _client.CreateGlobalApplicationCommandAsync(desiredCommands[i]);
-                }
-            }
+            var b = await _client.GetApplicationInfoAsync();
+
+            await _client.BulkOverwriteGlobalApplicationCommandsAsync(desiredCommands);
+
+            // for (int i = 0; i < desiredCommands.Length; i++)
+            // {
+            //     // only create if nothing similar was found
+            //     if (existingCommands.FirstOrDefault(
+            //         x => x.Name == desiredCommands[i].Name.GetValueOrDefault()
+            //         && x.Description == desiredCommands[i].Description.GetValueOrDefault()
+            //         && x.Options.Count == desiredCommands[i].Options.GetValueOrDefault().Count) == null)
+            //     {
+            //         await _client.CreateGlobalApplicationCommandAsync(desiredCommands[i]);
+            //     }
+            // }
+        }
+
+        private async Task OnSlashCommandExecuted(SocketSlashCommand cmd)
+        {
+            await cmd.DeferAsync();
+            var a = cmd.Data.Name;
         }
 
         private async Task OnMessageReceived(SocketMessage msg)

--- a/src/AdvancedBot.Core/Services/PaginatorService.cs
+++ b/src/AdvancedBot.Core/Services/PaginatorService.cs
@@ -27,7 +27,7 @@ namespace AdvancedBot.Core.Services
             _client = client;
             _client.InteractionCreated += OnInteraction;
         }
-        public async Task<IUserMessage> HandleNewPaginatedMessageAsync(SocketCommandContext context, IEnumerable<EmbedField> displayFields, IEnumerable<string> displayTexts, Embed embed)
+        public async Task<IUserMessage> HandleNewPaginatedMessageAsync(CommandContext context, IEnumerable<EmbedField> displayFields, IEnumerable<string> displayTexts, Embed embed)
         {
             var message = await context.Channel.SendMessageAsync("", false, embed, component: CreateMessageComponents());
             var paginatedMessage = new PaginatedMessage()

--- a/src/AdvancedBot.Core/Services/PaginatorService.cs
+++ b/src/AdvancedBot.Core/Services/PaginatorService.cs
@@ -29,7 +29,7 @@ namespace AdvancedBot.Core.Services
         }
         public async Task<IUserMessage> HandleNewPaginatedMessageAsync(CommandContext context, IEnumerable<EmbedField> displayFields, IEnumerable<string> displayTexts, Embed embed)
         {
-            var message = await context.Channel.SendMessageAsync("", false, embed, component: CreateMessageComponents());
+            var message = await context.Channel.SendMessageAsync("", false, embed, components: CreateMessageComponents());
             var paginatedMessage = new PaginatedMessage()
             {
                 DiscordMessageId = message.Id,


### PR DESCRIPTION
This PR will implement support for slash commands easily.
This will be done through Attributes, seeing as I do not like the current way the Discord.Net library would like you to implement it.

## Checklist
- [x] Generate Slash Commands based on the attribute
- [ ] Refactor and general cleanup
- [x] Fire corresponding methods when a slash command is executed